### PR TITLE
Make read_raw struct methods public

### DIFF
--- a/src/pmsa003i.rs
+++ b/src/pmsa003i.rs
@@ -68,7 +68,7 @@ impl<I2C: I2c> Pmsa003i<I2C> {
 
     /// Blocking raw read
     #[cfg(not(feature = "async"))]
-    fn read_raw(&mut self) -> Result<[u8; RESPONSE_LENGTH], Error<I2C::Error>> {
+    pub fn read_raw(&mut self) -> Result<[u8; RESPONSE_LENGTH], Error<I2C::Error>> {
         let mut response = [0; RESPONSE_LENGTH];
 
         self.i2c
@@ -86,7 +86,7 @@ impl<I2C: I2c> Pmsa003i<I2C> {
 
     /// Async raw read
     #[cfg(feature = "async")]
-    async fn read_raw(&mut self) -> Result<[u8; RESPONSE_LENGTH], Error<I2C::Error>> {
+    pub async fn read_raw(&mut self) -> Result<[u8; RESPONSE_LENGTH], Error<I2C::Error>> {
         let mut response = [0; RESPONSE_LENGTH];
 
         self.i2c


### PR DESCRIPTION
Adding these methods to the public API for `Pmsa003i` eliminates forced type conversions to/from `Reading` when the raw byte array is what the user needs.

Scenario: a LoRa end device needs to transmit Pmsa003i sensor readings as byte arrays to a LoRa gateway that will be responsible for parsing the byte arrays into something more usable (e.g. `Reading`).